### PR TITLE
Feature/trainingwheelsoncmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,13 +193,18 @@ else()
             # Check if fmt target is installable (not an imported target)
             get_target_property(FMT_IMPORTED fmt::fmt IMPORTED)
             if(NOT FMT_IMPORTED)
-                install(TARGETS fmt::fmt
-                    EXPORT MexUtilitiesTargets
-                    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-                    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-                )
+                # Use the actual fmt target, not the alias
+                if(TARGET fmt)
+                    install(TARGETS fmt
+                        EXPORT MexUtilitiesTargets
+                        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+                    )
+                else()
+                    message(WARNING "fmt::fmt alias exists but fmt target not found for installation")
+                endif()
             endif()
         endif()
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ include(GNUInstallDirs)
 option(BUILD_TESTS "Build tests" ON)
 option(USE_EIGEN "Provide eigen3 interfaces" ON)
 option(NO_MATLAB "Supress use of mexes etc" OFF)
+option(MEXUTILITIES_INSTALL_DEPS "Install fetched dependencies (fmt, eigen3)" OFF)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
@@ -28,12 +29,48 @@ endif()
 
 include(FetchContent)
 
-FetchContent_Declare(
-  fmtlib
-  GIT_REPOSITORY https://github.com/fmtlib/fmt
-  GIT_TAG        12.1.0)
-FetchContent_MakeAvailable(fmtlib)
+# Handle fmt dependency with version compatibility
+set(MEXUTILITIES_MIN_FMT_VERSION "10.0" CACHE STRING "Minimum required fmt version")
 
+# First, check if fmt target already exists (from parent project or previous FetchContent)
+if(TARGET fmt::fmt)
+    message(STATUS "fmt target already exists, using existing version")
+    get_target_property(FMT_INCLUDE_DIRS fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
+    if(FMT_INCLUDE_DIRS)
+        # Try to determine version from existing target
+        message(STATUS "Using existing fmt::fmt target")
+    endif()
+else()
+    # Try to find fmt via find_package first
+    find_package(fmt ${MEXUTILITIES_MIN_FMT_VERSION} QUIET)
+    
+    if(NOT fmt_FOUND)
+        message(STATUS "fmt not found or version < ${MEXUTILITIES_MIN_FMT_VERSION}, fetching compatible version")
+        
+        # Check if someone else already declared fmtlib in FetchContent
+        FetchContent_GetProperties(fmtlib)
+        if(NOT fmtlib_POPULATED)
+            FetchContent_Declare(
+                fmtlib
+                GIT_REPOSITORY https://github.com/fmtlib/fmt
+                GIT_TAG        12.1.0
+            )
+            
+            # Only set FMT_INSTALL if we're the top-level project or explicitly requested
+            if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR OR MEXUTILITIES_INSTALL_DEPS)
+                set(FMT_INSTALL ON CACHE BOOL "" FORCE)
+            else()
+                set(FMT_INSTALL OFF CACHE BOOL "" FORCE)
+            endif()
+            
+            FetchContent_MakeAvailable(fmtlib)
+        else()
+            message(STATUS "fmtlib already populated by another project")
+        endif()
+    else()
+        message(STATUS "fmt found ${fmt_VERSION}")
+    endif()
+endif()
 
 add_library(MexUtilities INTERFACE)
 add_library(MexUtilities::MexUtilities ALIAS MexUtilities)
@@ -54,16 +91,20 @@ target_sources(MexUtilities PUBLIC
 
 set(MexUtilitiesLibraries fmt::fmt)
 if(NOT NO_MATLAB)
-list(APPEND MexUtiliesLibraries Matlab::mex)
+list(APPEND MexUtilitiesLibraries Matlab::mex)
 endif(NOT NO_MATLAB)
 if (USE_EIGEN)
-    FetchContent_Declare(
-        eigen3
-        GIT_REPOSITORY https://gitlab.com/libeigen/eigen
-        GIT_TAG 3.4
-    )
-    FetchContent_MakeAvailable(eigen3)
-    list(APPEND MexUtilitiesLibraries eigen3)
+    find_package(Eigen3 QUIET)
+    if(NOT Eigen3_FOUND)
+        FetchContent_Declare(
+            eigen3
+            GIT_REPOSITORY https://gitlab.com/libeigen/eigen
+            GIT_TAG 3.4
+        )
+        FetchContent_MakeAvailable(eigen3)
+        find_package(Eigen3 REQUIRED)
+    endif()
+    list(APPEND MexUtilitiesLibraries Eigen3::Eigen)
     target_compile_definitions(MexUtilities INTERFACE USE_EIGEN)
 endif(USE_EIGEN)
 
@@ -78,7 +119,8 @@ endif()
 
 if(BUILD_TESTS)
 include(CTest)
-
+find_package(GTest QUIET)
+if (NOT GTest_FOUND)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest
@@ -87,6 +129,7 @@ FetchContent_Declare(
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
+endif()
 
 if(NOT NO_MATLAB)
 find_package(Matlab REQUIRED COMPONENTS MAIN_PROGRAM)
@@ -95,7 +138,33 @@ enable_testing()
 add_subdirectory(test)
 endif(BUILD_TESTS)
 
-install(TARGETS MexUtilities fmt
+# Install MexUtilities and its dependencies
+# Only install fmt if we fetched it AND we're either top-level or explicitly requested
+if(TARGET fmt AND CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR OR MEXUTILITIES_INSTALL_DEPS)
+    # Check if fmt was created by us (FetchContent) vs found externally
+    get_target_property(FMT_SOURCE_DIR fmt::fmt SOURCE_DIR)
+    if(FMT_SOURCE_DIR)
+        # fmt was fetched, so we can install it
+        install(TARGETS fmt
+            EXPORT MexUtilitiesTargets
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
+    endif()
+endif()
+
+if(USE_EIGEN AND NOT Eigen3_FOUND)
+    # If we fetched Eigen3, install it too
+    install(TARGETS eigen
+        EXPORT MexUtilitiesTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+endif()
+
+install(TARGETS MexUtilities
     EXPORT MexUtilitiesTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -104,6 +173,31 @@ install(TARGETS MexUtilities fmt
 )
 
 install(EXPORT MexUtilitiesTargets
-      FILE MexUtilities.cmake
+      FILE MexUtilitiesTargets.cmake
       NAMESPACE MexUtilities::
-      DESTINATION cmake)
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MexUtilities)
+
+# Create and install package configuration files
+include(CMakePackageConfigHelpers)
+
+# Create MexUtilitiesConfig.cmake
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/MexUtilitiesConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/MexUtilitiesConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MexUtilities
+    PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+)
+
+# Create MexUtilitiesConfigVersion.cmake
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/MexUtilitiesConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+# Install the config files
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/MexUtilitiesConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/MexUtilitiesConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MexUtilities
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,17 +14,26 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 if(NOT NO_MATLAB)
-set(MATLAB_ADDITIONAL_VERSION 
-    "R2024b=24.2"
-    "R2025a=25.1"
-    "R2025b=25.2"
-)
-    if(NOT DEFINED Matlab_FOUND)
-    find_package(Matlab REQUIRED)
+    set(MATLAB_ADDITIONAL_VERSION 
+        "R2024b=24.2"
+        "R2025a=25.1"
+        "R2025b=25.2"
+    )
+    
+    # Only find Matlab if not already found
+    if(NOT DEFINED Matlab_FOUND OR NOT Matlab_FOUND)
+        find_package(Matlab REQUIRED)
     endif()
-matlab_get_release_name_from_version("${Matlab_VERSION}" Matlab_RELEASE_NAME)
-string(REGEX REPLACE "R([0-9]+)[ab]" "\\1" MATLAB_YEAR "${Matlab_RELEASE_NAME}")
-message(STATUS "Found Matlab version ${Matlab_RELEASE_NAME}, year ${MATLAB_YEAR}")
+    
+    # Ensure we have the required Matlab variables
+    if(Matlab_FOUND AND Matlab_VERSION)
+        matlab_get_release_name_from_version("${Matlab_VERSION}" Matlab_RELEASE_NAME)
+        string(REGEX REPLACE "R([0-9]+)[ab]" "\\1" MATLAB_YEAR "${Matlab_RELEASE_NAME}")
+        message(STATUS "Found Matlab version ${Matlab_RELEASE_NAME}, year ${MATLAB_YEAR}")
+    else()
+        message(WARNING "Matlab found but version information not available")
+        set(MATLAB_YEAR 2025)  # Default to current year to avoid issues
+    endif()
 endif()
 
 include(FetchContent)
@@ -34,12 +43,20 @@ set(MEXUTILITIES_MIN_FMT_VERSION "10.0" CACHE STRING "Minimum required fmt versi
 
 # First, check if fmt target already exists (from parent project or previous FetchContent)
 if(TARGET fmt::fmt)
-    message(STATUS "fmt target already exists, using existing version")
-    get_target_property(FMT_INCLUDE_DIRS fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
-    if(FMT_INCLUDE_DIRS)
-        # Try to determine version from existing target
-        message(STATUS "Using existing fmt::fmt target")
+    message(STATUS "fmt::fmt target already exists, using existing version")
+    
+    # Try to get version information if available
+    get_target_property(FMT_VERSION fmt::fmt VERSION)
+    if(FMT_VERSION)
+        message(STATUS "Using existing fmt::fmt target version ${FMT_VERSION}")
+        if(FMT_VERSION VERSION_LESS ${MEXUTILITIES_MIN_FMT_VERSION})
+            message(WARNING "Existing fmt version ${FMT_VERSION} is less than required minimum ${MEXUTILITIES_MIN_FMT_VERSION}")
+        endif()
+    else()
+        message(STATUS "Using existing fmt::fmt target (version unknown)")
     endif()
+    
+    set(fmt_FOUND TRUE)
 else()
     # Try to find fmt via find_package first
     find_package(fmt ${MEXUTILITIES_MIN_FMT_VERSION} QUIET)
@@ -64,12 +81,18 @@ else()
             endif()
             
             FetchContent_MakeAvailable(fmtlib)
+            message(STATUS "fmt fetched and made available")
         else()
             message(STATUS "fmtlib already populated by another project")
         endif()
     else()
-        message(STATUS "fmt found ${fmt_VERSION}")
+        message(STATUS "Found system fmt ${fmt_VERSION}")
     endif()
+endif()
+
+# Ensure we have the fmt::fmt target available
+if(NOT TARGET fmt::fmt)
+    message(FATAL_ERROR "fmt::fmt target not available after dependency resolution")
 endif()
 
 add_library(MexUtilities INTERFACE)
@@ -93,28 +116,43 @@ set(MexUtilitiesLibraries fmt::fmt)
 if(NOT NO_MATLAB)
 list(APPEND MexUtilitiesLibraries Matlab::mex)
 endif(NOT NO_MATLAB)
-if (USE_EIGEN)
-    find_package(Eigen3 QUIET)
-    if(NOT Eigen3_FOUND)
-        FetchContent_Declare(
-            eigen3
-            GIT_REPOSITORY https://gitlab.com/libeigen/eigen
-            GIT_TAG 3.4
-        )
-        FetchContent_MakeAvailable(eigen3)
-        find_package(Eigen3 REQUIRED)
+if(USE_EIGEN)
+    # First check if Eigen3::Eigen target already exists
+    if(TARGET Eigen3::Eigen)
+        message(STATUS "Eigen3::Eigen target already exists, using existing version")
+        set(Eigen3_FOUND TRUE)
+    else()
+        find_package(Eigen3 QUIET)
+        if(NOT Eigen3_FOUND)
+            message(STATUS "Eigen3 not found, fetching from source")
+            FetchContent_Declare(
+                eigen3
+                GIT_REPOSITORY https://gitlab.com/libeigen/eigen
+                GIT_TAG 3.4
+            )
+            FetchContent_MakeAvailable(eigen3)
+            # After FetchContent, the target should be available
+            if(TARGET Eigen3::Eigen)
+                set(Eigen3_FOUND TRUE)
+            else()
+                message(FATAL_ERROR "Failed to make Eigen3::Eigen target available")
+            endif()
+        else()
+            message(STATUS "Found system Eigen3")
+        endif()
     endif()
+    
     list(APPEND MexUtilitiesLibraries Eigen3::Eigen)
     target_compile_definitions(MexUtilities INTERFACE USE_EIGEN)
-endif(USE_EIGEN)
+endif()
 
 target_link_libraries(MexUtilities INTERFACE ${MexUtilitiesLibraries})
 
 target_compile_features(MexUtilities INTERFACE cxx_std_20)
 
-if (MATLAB_YEAR LESS 2025)
-target_compile_definitions(MexUtilities INTERFACE REDUCED_TYPES)
-message(STATUS "Using REDUCED_TYPES for Matlab versions before 2025")
+if(NOT NO_MATLAB AND DEFINED MATLAB_YEAR AND MATLAB_YEAR LESS 2025)
+    target_compile_definitions(MexUtilities INTERFACE REDUCED_TYPES)
+    message(STATUS "Using REDUCED_TYPES for Matlab versions before 2025")
 endif()
 
 if(BUILD_TESTS)
@@ -140,28 +178,44 @@ endif(BUILD_TESTS)
 
 # Install MexUtilities and its dependencies
 # Only install fmt if we fetched it AND we're either top-level or explicitly requested
-if(TARGET fmt AND CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR OR MEXUTILITIES_INSTALL_DEPS)
+if((CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR OR MEXUTILITIES_INSTALL_DEPS) AND TARGET fmt::fmt)
     # Check if fmt was created by us (FetchContent) vs found externally
     get_target_property(FMT_SOURCE_DIR fmt::fmt SOURCE_DIR)
-    if(FMT_SOURCE_DIR)
-        # fmt was fetched, so we can install it
-        install(TARGETS fmt
-            EXPORT MexUtilitiesTargets
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        )
+    get_target_property(FMT_BINARY_DIR fmt::fmt BINARY_DIR)
+    
+    # Only install if fmt was fetched (has SOURCE_DIR and BINARY_DIR from FetchContent)
+    if(FMT_SOURCE_DIR AND FMT_BINARY_DIR AND EXISTS "${FMT_SOURCE_DIR}/CMakeLists.txt")
+        # Check if fmt target is installable (not an imported target)
+        get_target_property(FMT_IMPORTED fmt::fmt IMPORTED)
+        if(NOT FMT_IMPORTED)
+            install(TARGETS fmt::fmt
+                EXPORT MexUtilitiesTargets
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+            )
+        endif()
     endif()
 endif()
 
-if(USE_EIGEN AND NOT Eigen3_FOUND)
-    # If we fetched Eigen3, install it too
-    install(TARGETS eigen
-        EXPORT MexUtilitiesTargets
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    )
+if(USE_EIGEN AND TARGET Eigen3::Eigen)
+    # Check if Eigen3 was fetched by us
+    get_target_property(EIGEN_SOURCE_DIR Eigen3::Eigen SOURCE_DIR)
+    get_target_property(EIGEN_IMPORTED Eigen3::Eigen IMPORTED)
+    
+    if(EIGEN_SOURCE_DIR AND NOT EIGEN_IMPORTED AND (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR OR MEXUTILITIES_INSTALL_DEPS))
+        # Only install eigen if it was fetched and is installable
+        if(TARGET eigen)
+            install(TARGETS eigen
+                EXPORT MexUtilitiesTargets
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+            )
+        endif()
+    endif()
 endif()
 
 install(TARGETS MexUtilities

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ target_sources(MexUtilities PUBLIC
         utilities/eigen/conversions.hpp
         utilities/eigen/sparse.hpp
 )
-
+target_compile_definitions(MexUtilities INTERFACE TOOLNAME="$<UPPER_CASE:$<TARGET_PROPERTY:OUTPUT_NAME>>")
 
 set(MexUtilitiesLibraries fmt::fmt)
 if(NOT NO_MATLAB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ else()
             FetchContent_Declare(
                 fmtlib
                 GIT_REPOSITORY https://github.com/fmtlib/fmt
-                GIT_TAG        12.1.0
+                GIT_TAG        11.2.0
             )
             
             # Only set FMT_INSTALL if we're the top-level project or explicitly requested

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,82 +176,92 @@ enable_testing()
 add_subdirectory(test)
 endif(BUILD_TESTS)
 
-# Install MexUtilities and its dependencies
-# Only install fmt if we fetched it AND we're either top-level or explicitly requested
-if((CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR OR MEXUTILITIES_INSTALL_DEPS) AND TARGET fmt::fmt)
-    # Check if fmt was created by us (FetchContent) vs found externally
-    get_target_property(FMT_SOURCE_DIR fmt::fmt SOURCE_DIR)
-    get_target_property(FMT_BINARY_DIR fmt::fmt BINARY_DIR)
+# Only install when MexUtilities is the top-level project or installation is explicitly requested
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR OR MEXUTILITIES_INSTALL_DEPS)
+    message(STATUS "MexUtilities: Installing targets and exports")
+else()
+    message(STATUS "MexUtilities: Skipping install targets (used via FetchContent)")
     
-    # Only install if fmt was fetched (has SOURCE_DIR and BINARY_DIR from FetchContent)
-    if(FMT_SOURCE_DIR AND FMT_BINARY_DIR AND EXISTS "${FMT_SOURCE_DIR}/CMakeLists.txt")
-        # Check if fmt target is installable (not an imported target)
-        get_target_property(FMT_IMPORTED fmt::fmt IMPORTED)
-        if(NOT FMT_IMPORTED)
-            install(TARGETS fmt::fmt
-                EXPORT MexUtilitiesTargets
-                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-                INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-            )
+    # Install fmt if we fetched it
+    if(TARGET fmt::fmt)
+        # Check if fmt was created by us (FetchContent) vs found externally
+        get_target_property(FMT_SOURCE_DIR fmt::fmt SOURCE_DIR)
+        get_target_property(FMT_BINARY_DIR fmt::fmt BINARY_DIR)
+        
+        # Only install if fmt was fetched (has SOURCE_DIR and BINARY_DIR from FetchContent)
+        if(FMT_SOURCE_DIR AND FMT_BINARY_DIR AND EXISTS "${FMT_SOURCE_DIR}/CMakeLists.txt")
+            # Check if fmt target is installable (not an imported target)
+            get_target_property(FMT_IMPORTED fmt::fmt IMPORTED)
+            if(NOT FMT_IMPORTED)
+                install(TARGETS fmt::fmt
+                    EXPORT MexUtilitiesTargets
+                    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+                )
+            endif()
         endif()
     endif()
-endif()
 
-if(USE_EIGEN AND TARGET Eigen3::Eigen)
-    # Check if Eigen3 was fetched by us
-    get_target_property(EIGEN_SOURCE_DIR Eigen3::Eigen SOURCE_DIR)
-    get_target_property(EIGEN_IMPORTED Eigen3::Eigen IMPORTED)
-    
-    if(EIGEN_SOURCE_DIR AND NOT EIGEN_IMPORTED AND (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR OR MEXUTILITIES_INSTALL_DEPS))
-        # Only install eigen if it was fetched and is installable
-        if(TARGET eigen)
-            install(TARGETS eigen
-                EXPORT MexUtilitiesTargets
-                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-                INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-            )
+    # Install Eigen3 if we fetched it
+    if(USE_EIGEN AND TARGET Eigen3::Eigen)
+        # Check if Eigen3 was fetched by us
+        get_target_property(EIGEN_SOURCE_DIR Eigen3::Eigen SOURCE_DIR)
+        get_target_property(EIGEN_IMPORTED Eigen3::Eigen IMPORTED)
+        
+        if(EIGEN_SOURCE_DIR AND NOT EIGEN_IMPORTED)
+            # Only install eigen if it was fetched and is installable
+            if(TARGET eigen)
+                install(TARGETS eigen
+                    EXPORT MexUtilitiesTargets
+                    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+                )
+            endif()
         endif()
     endif()
+
+    # Install MexUtilities
+    install(TARGETS MexUtilities
+        EXPORT MexUtilitiesTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        FILE_SET headers DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/utilities
+    )
+
+    # Install the export set
+    install(EXPORT MexUtilitiesTargets
+          FILE MexUtilitiesTargets.cmake
+          NAMESPACE MexUtilities::
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MexUtilities)
+          
+    # Create and install package configuration files
+    include(CMakePackageConfigHelpers)
+
+    # Create MexUtilitiesConfig.cmake
+    configure_package_config_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/MexUtilitiesConfig.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/MexUtilitiesConfig.cmake"
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MexUtilities
+        PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+    )
+
+    # Create MexUtilitiesConfigVersion.cmake
+    write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/MexUtilitiesConfigVersion.cmake"
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
+
+    # Install the config files
+    install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/MexUtilitiesConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/MexUtilitiesConfigVersion.cmake"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MexUtilities
+    )
+    
 endif()
-
-install(TARGETS MexUtilities
-    EXPORT MexUtilitiesTargets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    FILE_SET headers DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/utilities
-)
-
-install(EXPORT MexUtilitiesTargets
-      FILE MexUtilitiesTargets.cmake
-      NAMESPACE MexUtilities::
-      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MexUtilities)
-
-# Create and install package configuration files
-include(CMakePackageConfigHelpers)
-
-# Create MexUtilitiesConfig.cmake
-configure_package_config_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/MexUtilitiesConfig.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/MexUtilitiesConfig.cmake"
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MexUtilities
-    PATH_VARS CMAKE_INSTALL_INCLUDEDIR
-)
-
-# Create MexUtilitiesConfigVersion.cmake
-write_basic_package_version_file(
-    "${CMAKE_CURRENT_BINARY_DIR}/MexUtilitiesConfigVersion.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
-)
-
-# Install the config files
-install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/MexUtilitiesConfig.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/MexUtilitiesConfigVersion.cmake"
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MexUtilities
-)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,9 +178,6 @@ endif(BUILD_TESTS)
 
 # Only install when MexUtilities is the top-level project or installation is explicitly requested
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR OR MEXUTILITIES_INSTALL_DEPS)
-    message(STATUS "MexUtilities: Installing targets and exports")
-else()
-    message(STATUS "MexUtilities: Skipping install targets (used via FetchContent)")
     
     # Install fmt if we fetched it
     if(TARGET fmt::fmt)

--- a/cmake/MexUtilitiesConfig.cmake.in
+++ b/cmake/MexUtilitiesConfig.cmake.in
@@ -1,0 +1,41 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Define minimum required versions
+set(_mexutilities_min_fmt_version "@MEXUTILITIES_MIN_FMT_VERSION@")
+
+# Find required dependencies - check if fmt target already exists first
+if(NOT TARGET fmt::fmt)
+    # Try to find fmt with minimum version requirement
+    find_dependency(fmt ${_mexutilities_min_fmt_version})
+else()
+    # fmt::fmt target exists, verify it meets our minimum requirements if possible
+    get_target_property(_fmt_version fmt::fmt VERSION)
+    if(_fmt_version AND _fmt_version VERSION_LESS ${_mexutilities_min_fmt_version})
+        message(WARNING "Found fmt version ${_fmt_version} but MexUtilities requires >= ${_mexutilities_min_fmt_version}")
+    endif()
+endif()
+
+# Handle Eigen3 if USE_EIGEN was enabled during build
+if(@USE_EIGEN@)
+    if(NOT TARGET Eigen3::Eigen)
+        find_dependency(Eigen3)
+    endif()
+endif()
+
+# Handle Matlab if NO_MATLAB was not set during build
+if(NOT @NO_MATLAB@)
+    if(NOT TARGET Matlab::mex)
+        find_package(Matlab QUIET)
+        if(NOT Matlab_FOUND)
+            message(WARNING "Matlab not found. MexUtilities was built with Matlab support but Matlab is not available.")
+        endif()
+    endif()
+endif()
+
+# Include the targets file
+include("${CMAKE_CURRENT_LIST_DIR}/MexUtilitiesTargets.cmake")
+
+# Verify that all expected targets were imported
+check_required_components(MexUtilities)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,14 @@ matlab_add_mex(
 )
 
 matlab_add_mex(
+    NAME warnanderror_mex
+    OUTPUT_NAME warnanderror
+    SRC src/warningsanderror.cpp
+    LINK_TO MexUtilities
+    R2018a
+)
+
+matlab_add_mex(
     NAME mex_name
     SRC src/mexName.cpp
     LINK_TO MexUtilities

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,10 @@ int main() {
 HAVE_CPP20)
 
 if(NOT NO_MATLAB)
+get_target_property(Matlab_Mex_Path Matlab::mex IMPORTED_LOCATION)
+cmake_path(GET Matlab_Mex_Path PARENT_PATH Matlab_Library_DIR)
+
+
 matlab_add_mex(
     NAME isfield_mex
     SRC src/isfield.cpp
@@ -73,22 +77,23 @@ target_include_directories(multifile PRIVATE src)
 matlab_add_mex(
     NAME page_times
     SRC src/pagetimes.cpp
-    LINK_TO MexUtilities $<IF:$<PLATFORM_ID:Linux>,mwblas,libmwblas.lib>
+    LINK_TO MexUtilities $<IF:$<PLATFORM_ID:Windows>,libmwblas.lib,mwblas>
     R2018a
 )
-if(WIN32)
-target_link_directories(page_times PRIVATE ${Matlab_ROOT_DIR}/extern/lib/win64/microsoft)
-endif(WIN32)
+
+target_link_directories(page_times PRIVATE ${Matlab_Library_DIR})
+
 
 matlab_add_mex(
     NAME catandpagetimes
     SRC src/catandpagetimes.cpp
-    LINK_TO MexUtilities $<IF:$<PLATFORM_ID:Linux>,mwblas,libmwblas.lib>
+    LINK_TO MexUtilities $<IF:$<PLATFORM_ID:Windows>,libmwblas.lib,mwblas>
     R2018a
 )
-if (WIN32)
-target_link_directories(catandpagetimes PRIVATE ${Matlab_ROOT_DIR}/extern/lib/win64/microsoft)
-endif(WIN32)
+
+target_link_directories(catandpagetimes PRIVATE ${Matlab_Library_DIR})
+
+
 target_compile_features(catandpagetimes PRIVATE cxx_std_23)
 
 matlab_add_mex(
@@ -102,12 +107,12 @@ target_compile_features(ranges PRIVATE cxx_std_23)
 matlab_add_mex(
     NAME catandpagetimesRanges
     SRC src/catandpagetimesranges.cpp
-    LINK_TO MexUtilities $<IF:$<PLATFORM_ID:Linux>,mwblas,libmwblas.lib>
+    LINK_TO MexUtilities $<IF:$<PLATFORM_ID:Windows>,libmwblas.lib,mwblas>
     R2018a
 )
-if (WIN32)
-target_link_directories(catandpagetimesRanges PRIVATE ${Matlab_ROOT_DIR}/extern/lib/win64/microsoft)
-endif(WIN32)
+
+target_link_directories(catandpagetimesRanges PRIVATE ${Matlab_Library_DIR})
+
 target_compile_features(catandpagetimesRanges PRIVATE cxx_std_23)
 
 if (USE_EIGEN)

--- a/test/src/warningsanderror.cpp
+++ b/test/src/warningsanderror.cpp
@@ -1,0 +1,28 @@
+#include "mex.hpp"
+#include "mexAdapter.hpp"
+#include "utilities.hpp"
+
+class MexFunction 
+    : public matlab::mex::Function 
+{
+
+public:
+    MexFunction()  {
+            matlabPtr = getEngine();
+    }
+    ~MexFunction() = default;
+    void operator()([[maybe_unused]]matlab::mex::ArgumentList outputs, matlab::mex::ArgumentList inputs) {
+        if (inputs.size()) {
+            std::string cmd = utilities::getstringvalue(inputs[0]);
+            if ("warn" == cmd) {
+                utilities::warning("This is an unspecific warning message");
+            } else if ("wspec" == cmd) {
+                utilities::warnWithId("specific", "This is a specific warning message");
+            } else {
+                utilities::printf("Pass one of the following commands as input: warn, wspec, err, espec\n");
+            }
+        } else {
+            utilities::printf("Pass one of the following commands as input: warn, wspec, err, espec\n");
+        }
+    }
+};


### PR DESCRIPTION
This PR adds some safeguards for including the utilities via fetchcontent in case where fmt or eigen is already defined in the outer project. Similarly it will omit searching for an arbitrary version of matlab if the outer project already has declared a particular version