### PR TITLE
Fix gcc-16 build (force-include <cstdint>) + non-square BlockData::transpose

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,26 @@ if(WIN32 AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
     target_compile_options(MexUtilities INTERFACE /EHsc)
 endif()
 
+# GCC 16's libstdc++ tightened transitive includes: standard headers no
+# longer silently drag in <cstdint>.  MATLAB's own MatlabDataArray headers
+# (e.g. GetArrayType.hpp) use int8_t / uint8_t / ... *without* including
+# <cstdint>, so every TU that pulls in mex.hpp / MatlabDataArray.hpp now
+# fails under gcc-16 with "'int8_t' was not declared in this scope".  We
+# cannot patch the installed MATLAB headers, and we cannot rely on one of
+# our own headers being included first -- the standard MEX pattern includes
+# mex.hpp + mexAdapter.hpp ahead of utilities.hpp (see test/src/mexName.cpp),
+# so a source-level #include lands too late.  Force-include <cstdint> ahead
+# of every TU that consumes MexUtilities so the fixed-width integer types
+# are in scope before any MATLAB header is processed.  Scoped to GNU-style
+# frontends (gcc, clang); the MSVC-style toolchains (cl, clang-cl, icx-cl)
+# use the MSVC STL and are unaffected.  Guarded by COMPILE_LANGUAGE:CXX so it
+# is not forced onto the C TU (c_mexapi_version.c) that matlab_add_mex pulls
+# into every mex -- <cstdint> is a C++-only header.  The SHELL: prefix keeps
+# "-include cstdint" as two separate arguments.
+if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU")
+    target_compile_options(MexUtilities INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-include cstdint>")
+endif()
+
 set(MexUtilitiesLibraries fmt::fmt)
 if(NOT NO_MATLAB)
 list(APPEND MexUtilitiesLibraries Matlab::mex)

--- a/utilities/details/blockdata.hpp
+++ b/utilities/details/blockdata.hpp
@@ -397,22 +397,32 @@ public:
     void transpose() {
         static_assert(N > 1, "Transpose is only valid for 2D or higher dimensions");
         if constexpr (N == 2) {
-            std::size_t nRows = _dims.at(0);
-            std::size_t nCols = _dims.at(1);
-            _dims.at(0) = nCols;
-            _dims.at(1) = nRows;
+            const std::size_t nRows = _dims.at(0);
+            const std::size_t nCols = _dims.at(1);
+            // The previous in-place pairwise swap only works for square
+            // matrices: for a non-square matrix the source/destination linear
+            // indices (column-major) do not pair up once the row stride
+            // changes, so elements were overwritten and the result was wrong.
+            // Transpose out-of-place into a fresh buffer, which is correct for
+            // both square and non-square shapes.  Old element (iRow, jCol) at
+            // iRow + jCol*nRows maps to new element (jCol, iRow) at
+            // jCol + iRow*nCols (nCols is the row stride of the transpose).
+            std::vector<T> transposed(_data.size());
             for (std::size_t jCol = 0; jCol < nCols; ++jCol) {
-                for (std::size_t iRow = jCol + 1; iRow < nRows; ++iRow) {
-                    std::swap(_data[iRow + jCol * nRows], _data[jCol + iRow * nCols]);
+                for (std::size_t iRow = 0; iRow < nRows; ++iRow) {
+                    transposed[jCol + iRow * nCols] = _data[iRow + jCol * nRows];
                 }
             }
+            _data = std::move(transposed);
+            _dims.at(0) = nCols;
+            _dims.at(1) = nRows;
             column.resize(_dims, _data.data());
             row.resize(_dims, _data.data());
             page.resize(_dims, _data.data());
             tensorial.resize(_dims, _data.data());
         }
         else if constexpr (N == 3) {
-            // Transpose logic for 3D tensors  
+            // Transpose logic for 3D tensors
         }
     }
 


### PR DESCRIPTION
Two fixes prompted by upgrading to GCC 16 (MinGW-w64).

## 1. gcc-16 build fix (`CMakeLists.txt`)

GCC 16's libstdc++ tightened its transitive includes: standard headers no longer silently pull in `<cstdint>`. MATLAB's `MatlabDataArray` headers (e.g. `GetArrayType.hpp`) use `int8_t`/`uint8_t`/… **without** including `<cstdint>`, so every translation unit that pulls in `mex.hpp` / `MatlabDataArray.hpp` now fails under gcc-16 with `'int8_t' was not declared in this scope`.

We can't patch the installed MATLAB headers, and we can't rely on one of our own headers being included first — the standard MEX pattern includes `mex.hpp` + `mexAdapter.hpp` ahead of `utilities.hpp` (see `test/src/mexName.cpp`), so a source-level `#include` would land too late. Instead, force-include `<cstdint>` via the `MexUtilities` INTERFACE target so the fixed-width integer types are in scope before any MATLAB header is processed, for every consumer.

- Scoped to GNU-style frontends (gcc, clang); MSVC-style toolchains (cl, clang-cl, icx-cl) use the MSVC STL and are unaffected.
- Guarded by `COMPILE_LANGUAGE:CXX` so the C TU (`c_mexapi_version.c`) that `matlab_add_mex` injects is left untouched (`<cstdint>` is C++-only).
- Harmless, idempotent no-op on older gcc where the transitive include still happened, so **no version gate is needed** (confirmed against the [GCC 15 porting notes](https://gcc.gnu.org/gcc-15/porting_to.html)).

## 2. `BlockData::transpose()` non-square bug (`utilities/details/blockdata.hpp`)

`transpose()` used an in-place pairwise swap, which is only valid for square matrices. For a non-square matrix the column-major source/destination linear indices don't pair up once the row stride changes, so elements were overwritten and the result was wrong. Reimplemented out-of-place into a fresh buffer (correct for both square and non-square shapes), then move-back and swap the dims. The 3D branch remains an unimplemented stub as before.

## Testing

`ctest --preset windows-gcc-release-test` → **100% (22/22) passed** under GCC 16.1.0, including the previously-failing `BlockDataTest.Transpose` and the MATLAB-driven `mexTest` / `sparseTest` suites.
